### PR TITLE
Refactor for 0.3; standardized naming convention; specs done.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,16 +32,17 @@ var context = contextualize(['foo', 'bar']);
 // Contextualize
 app.use(context);
 
-app.use(context.of(middleware1));
-app.use(context.of(middleware2));
+// Use routes with the give context
+app.use(context.for(middleware1));
+app.use(context.for(middleware2));
 
 // Recover the context
 app.use(function (req, res, next) {
 
-	console.log(context.for(req, middleware1));
+	console.log(context.for(middleware1).of(req));
 	// { foo: 5, bar: 10 }
 
-	console.log(context.for(req, middleware2));
+	console.log(context.for(middleware2).of(req));
 	// { foo: 7, bar: 1 }
 
 	next();

--- a/example/server.js
+++ b/example/server.js
@@ -24,14 +24,14 @@ var context = contextualize(['foo', 'bar']);
 
 app.use(context);
 
-app.use(context.of(middleware1));
-app.use(context.of(middleware2));
+app.use(context.for(middleware1));
+app.use(context.for(middleware2));
 
 app.use(function result(req, res) {
-	console.log(context.for(req));
+	console.log(context.of(req));
 	res.status(200).send({
-		first: context.for(req, middleware1),
-		second: context.for(req, middleware2)
+		first: context.for(middleware1).of(req),
+		second: context.for(middleware2).of(req)
 	});
 });
 

--- a/lib/contextualize.js
+++ b/lib/contextualize.js
@@ -25,9 +25,6 @@ module.exports = function create(options) {
 	 * @returns {String} The context identifier.
 	 */
 	function get(object) {
-		if (!_.has(object, '__ctx_' + options.context)) {
-			throw new TypeError();
-		}
 		return object['__ctx_' + options.context];
 	}
 
@@ -68,79 +65,117 @@ module.exports = function create(options) {
 		throw new TypeError('Properties not strings: ' + invalid);
 	}
 
-	function context(req, source) {
+	function context(req) {
 		if (!_.has(req, options.context)) {
 			throw new TypeError('Uncontextualized.');
 		}
+		return req[options.context];
+	}
 
-		if (_.isUndefined(source)) {
-			return req[options.context];
+	function current(req) {
+		var ctx = context(req), key = options.get(req);
+		if (!_.has(ctx, key)) {
+			ctx[key] = { };
 		}
-
-		var key = options.get(source);
-
-		if (!_.has(req[options.context], key)) {
-			req[options.context][key] = { };
-		}
-
-		return req[options.context][key];
+		return ctx[key];
 	}
 
 	var count = 0;
 
 	/**
-	 * @param {String} name Name to associate with the middleware.
 	 * @param {Function} middleware Middleware to contextualize.
 	 * @returns {Function} Wrapped middleware.
 	 */
-	function use(name, middleware) {
-
-		if (_.isFunction(name)) {
-			middleware = name;
-			name = middleware.name || ('anon_' + (count++));
+	function wrap(middleware) {
+		if (!options.get(middleware)) {
+			if (middleware.name) {
+				options.set(middleware, middleware.name);
+			} else {
+				options.set(middleware, 'anon_' + (count++));
+			}
 		}
-
-		if (_.isEmpty(name)) {
-			throw new TypeError('Must provide a name.');
-		}
-
-		options.set(middleware, name);
-
 		return function inject(req, res, next) {
 			// Someone forgot to include the context middleware!
 			if (!_.has(req, options.context)) {
-				return next(new Error());
+				return next(new TypeError('Not contextualize.'));
 			}
-
-			options.set(req, name);
-			middleware(req, res, next);
+			options.set(req, options.get(middleware));
+			middleware(req, res, function unload(err) {
+				// Unload the context after the middleware has finished
+				options.set(req, null);
+				// Pass-thru
+				next(err);
+			});
 		};
+	}
+
+	function parallel(middlewares) {
+		return function run(req, res, next) {
+			// Count how many middlewares there are.
+			var remaining = middlewares.length;
+			// Called after each middleware has run.
+			function ran(err) {
+				if (err || --remaining <= 0) {
+					next(err);
+				}
+			}
+			// Loop through all the middlewares and call them.
+			for (var i = 0; i < middlewares.length; ++i) {
+				middlewares[i](req, res, ran);
+			}
+		};
+	}
+
+
+
+	function pick(req, set) {
+		if (_.isUndefined(this.context)) {
+			return context(req);
+		} else if (_.isArray(this.context) || set) {
+			return _.pick(context(req), this.context);
+		} else {
+			return context(req)[this.context];
+		}
 	}
 
 
 	function contextualize(req, property) {
 		Object.defineProperty(req, property, {
 			get: function getContextProperty() {
-				return context(req, req)[property];
+				return current(req)[property];
 			},
 			set: function setContextProperty(value) {
-				context(req, req)[property] = value;
+				current(req)[property] = value;
 			}
 		});
 	}
 
-	// Middleware that injects the contextualization.
 	function middleware(req, res, next) {
 		req[options.context] = { };
-		_.forEach(options.properties, function contextProperty(property) {
+		_.forEach(options.properties, function forProperty(property) {
 			contextualize(req, property);
 		});
 		next();
 	}
 
-	// Provide nice helper methods along with the middleware.
+	function wrapper(contexts) {
+		var fn, ctx;
+		if (_.isArray(contexts)) {
+			ctx = _.map(contexts, options.get);
+			fn = parallel(_.map(contexts, wrap));
+		} else {
+			ctx = options.get(contexts);
+			fn = wrap(contexts);
+		}
+		return _.assign(fn, this, {
+			context: ctx
+		});
+	}
+
 	return _.assign(middleware, {
-		for: context,
-		of: use
+		of: pick,
+		for: wrapper,
+		get: options.get,
+		set: options.set
 	});
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "express-context",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"description": "Data encapsulation for express.",
 	"author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
 	"keywords": [ "express", "context" ],
@@ -10,7 +10,7 @@
 		"type": "git",
 		"url": "https://github.com/izaakschroeder/express-context.git"
 	},
-	"main": "lib/header.js",
+	"main": "lib/contextualize.js",
 	"scripts": {
 		"test": "npm run lint && npm run spec && npm run coverage",
 		"spec": "NODE_PATH=lib NODE_ENV=test istanbul cover node_modules/.bin/_mocha -- -r test/helpers/chai -R spec test/spec",


### PR DESCRIPTION
Pretty major overhaul that just standardizes how context behaves and what methods are called to invoke that behavior. Also allows for the ability to include mixins for specific contexts. Documentation updated to match.

Should make development with this library more predictable and easier to follow. Also provides the ability to build fluent APIs on top of contexts.
