### PR TITLE
Support for chained mixins; automatically setup context.

### DIFF
--- a/lib/contextualize.js
+++ b/lib/contextualize.js
@@ -1,7 +1,8 @@
 
 'use strict';
 
-var _ = require('lodash');
+var _ = require('lodash'),
+	async = require('express-async');
 
 /**
  * Create middleware that transparently contextualizes specific properties.
@@ -94,11 +95,7 @@ module.exports = function create(options) {
 				options.set(middleware, 'anon_' + (count++));
 			}
 		}
-		return function inject(req, res, next) {
-			// Someone forgot to include the context middleware!
-			if (!_.has(req, options.context)) {
-				return next(new TypeError('Not contextualize.'));
-			}
+		return function wrapped(req, res, next) {
 			options.set(req, options.get(middleware));
 			middleware(req, res, function unload(err) {
 				// Unload the context after the middleware has finished
@@ -109,22 +106,7 @@ module.exports = function create(options) {
 		};
 	}
 
-	function parallel(middlewares) {
-		return function run(req, res, next) {
-			// Count how many middlewares there are.
-			var remaining = middlewares.length;
-			// Called after each middleware has run.
-			function ran(err) {
-				if (err || --remaining <= 0) {
-					next(err);
-				}
-			}
-			// Loop through all the middlewares and call them.
-			for (var i = 0; i < middlewares.length; ++i) {
-				middlewares[i](req, res, ran);
-			}
-		};
-	}
+
 
 
 
@@ -150,32 +132,43 @@ module.exports = function create(options) {
 		});
 	}
 
+	function inject(req) {
+		if (!_.has(req, options.context)) {
+			req[options.context] = { };
+			_.forEach(options.properties, function forProperty(property) {
+				contextualize(req, property);
+			});
+		}
+	}
+
 	function middleware(req, res, next) {
-		req[options.context] = { };
-		_.forEach(options.properties, function forProperty(property) {
-			contextualize(req, property);
-		});
+		inject(req);
 		next();
 	}
 
-	function wrapper(contexts) {
+	function chain(fn, properties) {
+		return _.assign(async.serial([this, fn]), this, properties);
+	}
+
+	function only(contexts) {
 		var fn, ctx;
 		if (_.isArray(contexts)) {
 			ctx = _.map(contexts, options.get);
-			fn = parallel(_.map(contexts, wrap));
+			fn = async.parallel(_.map(contexts, wrap));
 		} else {
 			ctx = options.get(contexts);
 			fn = wrap(contexts);
 		}
-		return _.assign(fn, this, {
+		return this.chain(fn, {
 			context: ctx
 		});
 	}
 
 	return _.assign(middleware, {
 		of: pick,
-		for: wrapper,
+		for: only,
 		get: options.get,
-		set: options.set
+		set: options.set,
+		chain: chain
 	});
 };

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
 		"coverage": "istanbul check-coverage --statement 100 --branch 100 --function 100"
 	},
 	"dependencies": {
-		"lodash": "^2.4.1"
+		"lodash": "^2.4.1",
+		"express-async": "^0.1.0"
 	},
 	"devDependencies": {
 		"eslint": "^0.10.0",

--- a/test/spec/contextualize.spec.js
+++ b/test/spec/contextualize.spec.js
@@ -41,14 +41,23 @@ describe('contextualize', function() {
 		}).to.throw(TypeError);
 	});
 
-	it('should fail if the context is not set', function(done) {
+	it('should automatically setup the context', function(done) {
 		var context = contextualize('magic');
 		this.app.use(context.for(function x(req, res, next) {
 			req.magic = 'lol';
 			next();
 		}));
+		this.app.get('/', function(req, res) {
+			res.status(200).send(context.of(req));
+		});
+
 		request(this.app).get('/').expect(function(res) {
-			expect(res.statusCode).to.equal(500);
+			expect(res.statusCode).to.equal(200);
+			expect(res.body).to.deep.equal({
+				x: {
+					magic: 'lol'
+				}
+			});
 		}).end(done);
 	});
 


### PR DESCRIPTION
Mixins now have the ability to call `.chain` on themselves to automatically inject all previous middleware in the chain (as well as existing properties on `this`). This allows for one to use the last entry in a mixin and not have to put in all the previous middlewares.

As a side-effect of this and to ensure a consistent API, the actual contextualization process is now also included in any middleware/mixin along the chain.

A dependency on `express-async` is introduced in order to keep the control-flow management out of this module.
