### PR TITLE
Dedicated function for mixins; chain doesn't add properties.

### DIFF
--- a/lib/contextualize.js
+++ b/lib/contextualize.js
@@ -146,8 +146,15 @@ module.exports = function create(options) {
 		next();
 	}
 
-	function chain(fn, properties) {
-		return _.assign(async.serial([this, fn]), this, properties);
+	function chain(fn) {
+		return _.assign(async.serial([this, fn]), this);
+	}
+
+	function mixin(properties) {
+		var self = this;
+		return _.assign(function mixee(req, res, next) {
+			self(req, res, next);
+		}, this, properties);
 	}
 
 	function only(contexts) {
@@ -169,6 +176,7 @@ module.exports = function create(options) {
 		for: only,
 		get: options.get,
 		set: options.set,
-		chain: chain
+		chain: chain,
+		mixin: mixin
 	});
 };

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"main": "lib/contextualize.js",
 	"scripts": {
 		"test": "npm run lint && npm run spec && npm run coverage",
-		"spec": "NODE_PATH=lib NODE_ENV=test istanbul cover node_modules/.bin/_mocha -- -r test/helpers/chai -R spec test/spec",
+		"spec": "NODE_PATH=lib NODE_ENV=test istanbul cover node_modules/.bin/_mocha -- -r test/helpers/chai -r test/helpers/sinon -R spec test/spec",
 		"lint": "eslint --ignore-path .gitignore .",
 		"coverage": "istanbul check-coverage --statement 100 --branch 100 --function 100"
 	},
@@ -28,6 +28,8 @@
 		"istanbul": "^0.3.2",
 		"chai": "^1.10.0",
 		"supertest": "^0.15.0",
-		"express": "^4.10.4"
+		"express": "^4.10.4",
+		"sinon": "^1.12.2",
+		"sinon-chai": "^2.6.0"
 	}
 }

--- a/test/helpers/chai.js
+++ b/test/helpers/chai.js
@@ -3,4 +3,6 @@
 
 var chai = require('chai');
 
+chai.use(require('sinon-chai'));
+
 global.expect = chai.expect;

--- a/test/helpers/sinon.js
+++ b/test/helpers/sinon.js
@@ -1,0 +1,6 @@
+
+'use strict';
+
+var sinon = require('sinon');
+
+global.sinon = sinon;

--- a/test/spec/contextualize.spec.js
+++ b/test/spec/contextualize.spec.js
@@ -150,6 +150,28 @@ describe('contextualize', function() {
 		});
 	});
 
+	describe('#mixin', function() {
+		it('should add desired properties', function() {
+			var context = contextualize('foo');
+			var res = context.mixin({
+				bar: 5
+			});
+			expect(res).to.have.property('bar', 5);
+			expect(context).not.to.have.property('bar');
+		});
+
+		it('should invoke the original function', function() {
+			var context = contextualize('foo'), stub = sinon.stub();
+			var res = context.mixin.call(stub, {
+				bar: 5
+			});
+			var req = { id: 1 };
+
+			res(req);
+			expect(stub).to.be.calledWith(req);
+		});
+	});
+
 	describe('#for', function() {
 		it('should return named middleware', function() {
 


### PR DESCRIPTION
There is now a dedicated function for performing mixins; this separates out some of the logic from chain. Extra tests have been added to verify the fact that the mixin calls the original function. Mixins are independent of their source function.

Sinon added for testing.
