### PR TITLE
Fix to ensure `for` actually names middleware.

### DIFF
--- a/lib/contextualize.js
+++ b/lib/contextualize.js
@@ -106,10 +106,6 @@ module.exports = function create(options) {
 		};
 	}
 
-
-
-
-
 	function pick(req, set) {
 		if (_.isUndefined(this.context)) {
 			return context(req);
@@ -119,7 +115,6 @@ module.exports = function create(options) {
 			return context(req)[this.context];
 		}
 	}
-
 
 	function contextualize(req, property) {
 		Object.defineProperty(req, property, {
@@ -160,15 +155,13 @@ module.exports = function create(options) {
 	function only(contexts) {
 		var fn, ctx;
 		if (_.isArray(contexts)) {
-			ctx = _.map(contexts, options.get);
 			fn = async.parallel(_.map(contexts, wrap));
+			ctx = _.map(contexts, options.get);
 		} else {
-			ctx = options.get(contexts);
 			fn = wrap(contexts);
+			ctx = options.get(contexts);
 		}
-		return this.chain(fn, {
-			context: ctx
-		});
+		return this.mixin({ context: ctx }).chain(fn);
 	}
 
 	return _.assign(middleware, {

--- a/test/spec/contextualize.spec.js
+++ b/test/spec/contextualize.spec.js
@@ -182,8 +182,7 @@ describe('contextualize', function() {
 			var context = contextualize('color');
 
 			expect(context.for(test)).to.be.instanceof(Function);
-			expect(context.get(test)).to.not.be.null;
-
+			expect(context.get(test)).to.be.a('string');
 		});
 
 		it('should inject local values to context chain', function(done) {


### PR DESCRIPTION
Bug from previous refactor. Test changed to ensure it gets caught.
