### PR TITLE
Remove default context name as function name.

### DIFF
--- a/lib/contextualize.js
+++ b/lib/contextualize.js
@@ -88,13 +88,18 @@ module.exports = function create(options) {
 	 * @returns {Function} Wrapped middleware.
 	 */
 	function wrap(middleware) {
-		if (!options.get(middleware)) {
-			if (middleware.name) {
-				options.set(middleware, middleware.name);
-			} else {
-				options.set(middleware, 'anon_' + (count++));
-			}
+
+		// Type safety
+		if (!_.isFunction(middleware)) {
+			throw new TypeError('Middleware must be a function.');
 		}
+
+		// Assign name if needed
+		if (!options.get(middleware)) {
+			options.set(middleware, 'middleware_ctx_' + (count++));
+		}
+
+		// Wrap
 		return function wrapped(req, res, next) {
 			options.set(req, options.get(middleware));
 			middleware(req, res, function unload(err) {


### PR DESCRIPTION
Its nice in some cases, but name collisions and returned closures make this too risky to be the default choice.
