### PR TITLE
Fixes for chaining when using `for([mw1,mw2,...])`.

### DIFF
--- a/lib/contextualize.js
+++ b/lib/contextualize.js
@@ -83,25 +83,9 @@ module.exports = function create(options) {
 
 	var count = 0;
 
-	/**
-	 * @param {Function} middleware Middleware to contextualize.
-	 * @returns {Function} Wrapped middleware.
-	 */
-	function wrap(middleware) {
-
-		// Type safety
-		if (!_.isFunction(middleware)) {
-			throw new TypeError('Middleware must be a function.');
-		}
-
-		// Assign name if needed
-		if (!options.get(middleware)) {
-			options.set(middleware, 'middleware_ctx_' + (count++));
-		}
-
-		// Wrap
+	function wrapper(middleware, name) {
 		return function wrapped(req, res, next) {
-			options.set(req, options.get(middleware));
+			options.set(req, name);
 			middleware(req, res, function unload(err) {
 				// Unload the context after the middleware has finished
 				options.set(req, null);
@@ -110,6 +94,36 @@ module.exports = function create(options) {
 			});
 		};
 	}
+
+	/**
+	 * @param {Function} middleware Middleware to contextualize.
+	 * @returns {Function} Wrapped middleware.
+	 */
+	function wrap(middleware) {
+
+		var key = '__ctx_wrap_' + options.name;
+
+		// Type safety
+		if (!_.isFunction(middleware)) {
+			throw new TypeError('Middleware must be a function.');
+		}
+
+		if (_.has(middleware, key)) {
+			return middleware;
+		}
+
+		if (!options.get(middleware)) {
+			options.set(middleware, 'middleware_ctx_' + (count++));
+		}
+
+		// Wrap
+		var name = options.get(middleware);
+		var w = wrapper(middleware, name);
+		options.set(w, name);
+		w[key] = true;
+		return w;
+	}
+
 
 	function pick(req, set) {
 		if (_.isUndefined(this.context)) {
@@ -132,22 +146,21 @@ module.exports = function create(options) {
 		});
 	}
 
-	function inject(req) {
+	function middleware(req, res, next) {
 		if (!_.has(req, options.context)) {
 			req[options.context] = { };
 			_.forEach(options.properties, function forProperty(property) {
 				contextualize(req, property);
 			});
 		}
-	}
-
-	function middleware(req, res, next) {
-		inject(req);
 		next();
 	}
 
 	function chain(fn) {
-		return _.assign(async.serial([this, fn]), this);
+		if (!_.isFunction(fn)) {
+			throw new TypeError('Must `chain` with function.');
+		}
+		return _.assign(async.serial([this, fn]), this, fn, null, null);
 	}
 
 	function mixin(properties) {
@@ -160,11 +173,12 @@ module.exports = function create(options) {
 	function only(contexts) {
 		var fn, ctx;
 		if (_.isArray(contexts)) {
-			fn = async.parallel(_.map(contexts, wrap));
+			contexts = _.map(contexts, wrap);
+			fn = async.parallel(contexts);
 			ctx = _.map(contexts, options.get);
 		} else {
 			fn = wrap(contexts);
-			ctx = options.get(contexts);
+			ctx = options.get(fn);
 		}
 		return this.mixin({ context: ctx }).chain(fn);
 	}


### PR DESCRIPTION
Chaining previously only set the context on the entire `for` block instead of the individual elements within it. We address the issue by ensuring that we prepare the context for a request only once, and that any middleware given is tagged as the original middleware and not some composed version. Additionally, any wrapped version of the middleware inherits the same context as the middleware itself.
