### PR TITLE
Repurpose `for` to set context name. Refactor `chain` into `use`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: node_js
 node_js:
 - '0.11'

--- a/example/server.js
+++ b/example/server.js
@@ -22,16 +22,14 @@ function middleware2(req, res, next) {
 
 var context = contextualize(['foo', 'bar']);
 
-app.use(context);
-
-app.use(context.for(middleware1));
-app.use(context.for(middleware2));
+app.use(context.for('a').use(middleware1));
+app.use(context.for('b').use(middleware2));
 
 app.use(function result(req, res) {
 	console.log(context.of(req));
 	res.status(200).send({
-		first: context.for(middleware1).of(req),
-		second: context.for(middleware2).of(req)
+		first: context.for('a').of(req),
+		second: context.for('b').of(req)
 	});
 });
 

--- a/lib/contextualize.js
+++ b/lib/contextualize.js
@@ -81,9 +81,7 @@ module.exports = function create(options) {
 		return ctx[key];
 	}
 
-	var count = 0;
-
-	function wrapper(middleware, name) {
+	function wrap(middleware, name) {
 		return function wrapped(req, res, next) {
 			options.set(req, name);
 			middleware(req, res, function unload(err) {
@@ -94,36 +92,6 @@ module.exports = function create(options) {
 			});
 		};
 	}
-
-	/**
-	 * @param {Function} middleware Middleware to contextualize.
-	 * @returns {Function} Wrapped middleware.
-	 */
-	function wrap(middleware) {
-
-		var key = '__ctx_wrap_' + options.name;
-
-		// Type safety
-		if (!_.isFunction(middleware)) {
-			throw new TypeError('Middleware must be a function.');
-		}
-
-		if (_.has(middleware, key)) {
-			return middleware;
-		}
-
-		if (!options.get(middleware)) {
-			options.set(middleware, 'middleware_ctx_' + (count++));
-		}
-
-		// Wrap
-		var name = options.get(middleware);
-		var w = wrapper(middleware, name);
-		options.set(w, name);
-		w[key] = true;
-		return w;
-	}
-
 
 	function pick(req, set) {
 		if (_.isUndefined(this.context)) {
@@ -156,11 +124,16 @@ module.exports = function create(options) {
 		next();
 	}
 
-	function chain(fn) {
-		if (!_.isFunction(fn)) {
-			throw new TypeError('Must `chain` with function.');
+	function use(fn) {
+		fn = async.series(_.flatten(arguments));
+		if (_.isArray(this.context)) {
+			fn = async.parallel(_.map(this.context, function wrapItem(context) {
+				return wrap(fn, context);
+			}));
+		} else if (this.context) {
+			fn = wrap(fn, this.context);
 		}
-		return _.assign(async.serial([this, fn]), this, fn, null, null);
+		return _.assign(async.series(this, fn), this, fn, null, null);
 	}
 
 	function mixin(properties) {
@@ -170,17 +143,17 @@ module.exports = function create(options) {
 		}, this, properties);
 	}
 
-	function only(contexts) {
-		var fn, ctx;
-		if (_.isArray(contexts)) {
-			contexts = _.map(contexts, wrap);
-			fn = async.parallel(contexts);
-			ctx = _.map(contexts, options.get);
-		} else {
-			fn = wrap(contexts);
-			ctx = options.get(fn);
+	function only(context) {
+		var singular = arguments.length === 1 && !_.isArray(context),
+			data = _.flatten(arguments);
+
+		if (!_.every(data, _.isString)) {
+			throw new TypeError();
 		}
-		return this.mixin({ context: ctx }).chain(fn);
+
+		return this.mixin({
+			context: singular ? context : data
+		});
 	}
 
 	return _.assign(middleware, {
@@ -188,7 +161,7 @@ module.exports = function create(options) {
 		for: only,
 		get: options.get,
 		set: options.set,
-		chain: chain,
+		use: use,
 		mixin: mixin
 	});
 };

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 	},
 	"dependencies": {
 		"lodash": "^2.4.1",
-		"express-async": "^0.1.2"
+		"express-async": "^0.1.3"
 	},
 	"devDependencies": {
 		"eslint": "^0.10.0",


### PR DESCRIPTION
Previously `for` did one too many things including: setting a context, binding that context to a function and then returning the chained result. Now it does considerably less and it is more clean what it does: it now just provides an object to chain middleware _for_ a certain context (or contexts). Code that previously used `ctx.for(mw1)` now has to rewrite it as `ctx.for('name').use(mw1)`. Other than that the behavior is just about the same. It gains the ability to accept obscure combinations of arguments for multiple contexts, so `ctx.for('a', ['b', 'c'], 'd')` is fine and flattened automatically.

The `chain` function has also received minor rework, now behaving much more like the express `use` call, so it has been renamed to match. `use` accepts middleware in the same manner as express does (flattened and run in serial), except that these middleware are ran once for each context previously set by `for`. So `ctx.for('a', 'b').use(mw1, mw2)` will run `mw1 -> mw2` in series bound to the context `'a'` _and_ `mw1 -> mw2` in series bound to the context `'b'`.

Overall this simplifies and clarifies use of the API and reduces the amount of code in the library.