### PR TITLE
Enable `deep` mode when flattening data.

### DIFF
--- a/lib/contextualize.js
+++ b/lib/contextualize.js
@@ -125,7 +125,7 @@ module.exports = function create(options) {
 	}
 
 	function use(fn) {
-		fn = async.series(_.flatten(arguments));
+		fn = async.series(arguments);
 		if (_.isArray(this.context)) {
 			fn = async.parallel(_.map(this.context, function wrapItem(context) {
 				return wrap(fn, context);
@@ -145,7 +145,7 @@ module.exports = function create(options) {
 
 	function only(context) {
 		var singular = arguments.length === 1 && !_.isArray(context),
-			data = _.flatten(arguments);
+			data = _.flatten(arguments, true);
 
 		if (!_.every(data, _.isString)) {
 			throw new TypeError();


### PR DESCRIPTION
The new version of `lodash` does not flatten by default, and `async.series` should have this behavior anyway.
